### PR TITLE
Handle short reads correctly

### DIFF
--- a/src/murmur3_32.rs
+++ b/src/murmur3_32.rs
@@ -8,6 +8,8 @@
 
 use std::io::{Read, Result};
 
+use crate::read_bytes;
+
 const C1: u32 = 0x85eb_ca6b;
 const C2: u32 = 0xc2b2_ae35;
 const R1: u32 = 16;
@@ -28,7 +30,7 @@ pub fn murmur3_32<T: Read>(source: &mut T, seed: u32) -> Result<u32> {
     let mut processed = 0;
     let mut state = seed;
     loop {
-        match source.read(&mut buffer)? {
+        match read_bytes(source, &mut buffer)? {
             4 => {
                 processed += 4;
                 let k = u32::from_le_bytes(buffer);

--- a/src/murmur3_x64_128.rs
+++ b/src/murmur3_x64_128.rs
@@ -9,7 +9,7 @@
 use std::io::{Read, Result};
 use std::ops::Shl;
 
-use crate::copy_into_array;
+use crate::{copy_into_array, read_bytes};
 
 /// Use the x64 variant of the 128 bit murmur3 to hash some [Read] implementation.
 ///
@@ -33,7 +33,7 @@ pub fn murmur3_x64_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
     let mut buf = [0; 16];
     let mut processed: usize = 0;
     loop {
-        let read = source.read(&mut buf[..])?;
+        let read = read_bytes(source, &mut buf[..])?;
         processed += read;
         if read == 16 {
             let k1 = u64::from_le_bytes(copy_into_array(&buf[0..8]));

--- a/src/murmur3_x86_128.rs
+++ b/src/murmur3_x86_128.rs
@@ -9,7 +9,7 @@
 use std::io::{Read, Result};
 use std::ops::Shl;
 
-use crate::copy_into_array;
+use crate::{copy_into_array, read_bytes};
 
 /// Use the x86 variant of the 128 bit murmur3 to hash some [Read] implementation.
 ///
@@ -38,7 +38,7 @@ pub fn murmur3_x86_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
     let mut buf = [0; 16];
     let mut processed: usize = 0;
     loop {
-        let read = source.read(&mut buf[..])?;
+        let read = read_bytes(source, &mut buf[..])?;
         processed += read;
         if read == 16 {
             let k1 = u32::from_le_bytes(copy_into_array(&buf[0..4]));


### PR DESCRIPTION
Short reads currently result in pad bytes being included at the point of the short read, resulting in bad hashes; this can occur anywhere, as std::io::Read makes no guarantees about the amount of bytes read by `read`.