### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [features]
 default = ["std"]
+alloc = []
 std = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ keywords = ["hash","murmur3","murmur"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 
+[features]
+no_std = []
+
 [dependencies]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [features]
-no_std = []
+default = ["std"]
+std = []
 
 [dependencies]
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
 
+extern crate murmur3;
 extern crate murmur3_sys;
 extern crate test;
-extern crate murmur3;
 
 use murmur3::*;
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,13 +2,11 @@
 
 extern crate murmur3_sys;
 extern crate test;
-
-use std::io::Cursor;
-use test::Bencher;
-
 extern crate murmur3;
 
 use murmur3::*;
+
+use test::Bencher;
 
 use murmur3_sys::MurmurHash3_x86_32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 
 //! A pure rust implementation of the fast, non-cryptographic hash [murmur3](https://en.wikipedia.org/wiki/MurmurHash)
 #![deny(missing_docs)]
-
 #![cfg_attr(feature = "no_std", no_std)]
 
 #[cfg(feature = "no_std")]
@@ -17,10 +16,10 @@ extern crate alloc;
 #[cfg(feature = "no_std")]
 mod no_std;
 #[cfg(feature = "no_std")]
-pub use no_std::{Read, Result, Cursor};
+pub use no_std::{Cursor, Read, Result};
 
 #[cfg(not(feature = "no_std"))]
-pub use std::io::{Read, Result, Cursor};
+pub use std::io::{Cursor, Read, Result};
 
 mod murmur3_32;
 mod murmur3_x64_128;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(not(feature = "std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,17 +8,17 @@
 
 //! A pure rust implementation of the fast, non-cryptographic hash [murmur3](https://en.wikipedia.org/wiki/MurmurHash)
 #![deny(missing_docs)]
-#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 mod no_std;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 pub use no_std::{Cursor, Read, Result};
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 pub use std::io::{Cursor, Read, Result};
 
 mod murmur3_32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,19 @@
 //! A pure rust implementation of the fast, non-cryptographic hash [murmur3](https://en.wikipedia.org/wiki/MurmurHash)
 #![deny(missing_docs)]
 
+#![cfg_attr(feature = "no_std", no_std)]
+
+#[cfg(feature = "no_std")]
+extern crate alloc;
+
+#[cfg(feature = "no_std")]
+mod no_std;
+#[cfg(feature = "no_std")]
+pub use no_std::{Read, Result, Cursor};
+
+#[cfg(not(feature = "no_std"))]
+pub use std::io::{Read, Result, Cursor};
+
 mod murmur3_32;
 mod murmur3_x64_128;
 mod murmur3_x86_128;

--- a/src/murmur3_32.rs
+++ b/src/murmur3_32.rs
@@ -6,7 +6,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use std::io::{Read, Result};
+use crate::{Read, Result};
 
 const C1: u32 = 0x85eb_ca6b;
 const C2: u32 = 0xc2b2_ae35;
@@ -19,8 +19,7 @@ const N: u32 = 0xe654_6b64;
 ///
 /// # Example
 /// ```
-/// use std::io::Cursor;
-/// use murmur3::murmur3_32;
+/// use murmur3::{Cursor, murmur3_32};
 /// let hash_result = murmur3_32(&mut Cursor::new("hello world"), 0);
 /// ```
 pub fn murmur3_32<T: Read>(source: &mut T, seed: u32) -> Result<u32> {

--- a/src/murmur3_x64_128.rs
+++ b/src/murmur3_x64_128.rs
@@ -30,7 +30,7 @@ pub fn murmur3_x64_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
     const M: u64 = 5;
     let mut h1: u64 = seed as u64;
     let mut h2: u64 = seed as u64;
-    let mut buf: [u8; 16] = [0; 16];
+    let mut buf = [0; 16];
     let mut processed: usize = 0;
     loop {
         let read = source.read(&mut buf)?;

--- a/src/murmur3_x64_128.rs
+++ b/src/murmur3_x64_128.rs
@@ -6,8 +6,9 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use std::io::{Read, Result};
-use std::ops::Shl;
+use crate::{Read, Result};
+
+use core::ops::Shl;
 
 use crate::copy_into_array;
 
@@ -15,8 +16,7 @@ use crate::copy_into_array;
 ///
 /// # Example
 /// ```
-/// use std::io::Cursor;
-/// use murmur3::murmur3_x64_128;
+/// use murmur3::{Cursor, murmur3_x64_128};
 /// let hash_result = murmur3_x64_128(&mut Cursor::new("hello world"), 0);
 /// ```
 pub fn murmur3_x64_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
@@ -30,10 +30,10 @@ pub fn murmur3_x64_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
     const M: u64 = 5;
     let mut h1: u64 = seed as u64;
     let mut h2: u64 = seed as u64;
-    let mut buf = [0; 16];
+    let mut buf: [u8; 16] = [0; 16];
     let mut processed: usize = 0;
     loop {
-        let read = source.read(&mut buf[..])?;
+        let read = source.read(&mut buf)?;
         processed += read;
         if read == 16 {
             let k1 = u64::from_le_bytes(copy_into_array(&buf[0..8]));

--- a/src/murmur3_x86_128.rs
+++ b/src/murmur3_x86_128.rs
@@ -6,8 +6,9 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use std::io::{Read, Result};
-use std::ops::Shl;
+use crate::{Read, Result};
+
+use core::ops::Shl;
 
 use crate::copy_into_array;
 
@@ -15,8 +16,7 @@ use crate::copy_into_array;
 ///
 /// # Example
 /// ```
-/// use std::io::Cursor;
-/// use murmur3::murmur3_x86_128;
+/// use murmur3::{Cursor, murmur3_x86_128};
 /// let hash_result = murmur3_x86_128(&mut Cursor::new("hello world"), 0);
 /// ```
 pub fn murmur3_x86_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
@@ -35,10 +35,10 @@ pub fn murmur3_x86_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
     let mut h3: u32 = seed;
     let mut h4: u32 = seed;
 
-    let mut buf = [0; 16];
+    let mut buf: [u8; 16] = [0; 16];
     let mut processed: usize = 0;
     loop {
-        let read = source.read(&mut buf[..])?;
+        let read = source.read(&mut buf)?;
         processed += read;
         if read == 16 {
             let k1 = u32::from_le_bytes(copy_into_array(&buf[0..4]));

--- a/src/murmur3_x86_128.rs
+++ b/src/murmur3_x86_128.rs
@@ -35,7 +35,7 @@ pub fn murmur3_x86_128<T: Read>(source: &mut T, seed: u32) -> Result<u128> {
     let mut h3: u32 = seed;
     let mut h4: u32 = seed;
 
-    let mut buf: [u8; 16] = [0; 16];
+    let mut buf = [0; 16];
     let mut processed: usize = 0;
     loop {
         let read = source.read(&mut buf)?;

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -5,7 +5,7 @@ use core::cmp::min;
 
 /// The error
 #[derive(Debug)]
-pub enum Error { }
+pub enum Error {}
 
 /// The result of reading
 pub type Result<T> = core::result::Result<T, Error>;
@@ -26,16 +26,12 @@ pub struct Cursor<T> {
 impl<T> Cursor<T> {
     /// Create a new cursor
     pub fn new(inner: T) -> Self {
-        Self {
-            inner,
-            pos: 0,
-        }
+        Self { inner, pos: 0 }
     }
 }
 
 impl Read for Cursor<&[u8]> {
     fn read<const N: usize>(&mut self, buffer: &mut [u8; N]) -> Result<usize> {
-
         // get number of items we can copy
         let n_items = min(self.inner.len() - self.pos, N);
 

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -1,5 +1,6 @@
 //! This file replaces some of std::io in a no_std environment
 
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::cmp::min;
 
@@ -43,6 +44,7 @@ impl Read for Cursor<&[u8]> {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl Read for Cursor<Vec<u8>> {
     fn read<const N: usize>(&mut self, buffer: &mut [u8; N]) -> Result<usize> {
         // get number of items we can copy

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -1,0 +1,86 @@
+//! This file replaces some of std::io in a no_std environment
+
+use alloc::vec::Vec;
+use core::cmp::min;
+
+/// The error
+#[derive(Debug)]
+pub enum Error { }
+
+/// The result of reading
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// A generic reading trait
+pub trait Read {
+    /// Read into a buffer.
+    /// @return the number of bytes read into the buffer
+    fn read<const N: usize>(&mut self, buffer: &mut [u8; N]) -> Result<usize>;
+}
+
+/// A Cursor
+pub struct Cursor<T> {
+    inner: T,
+    pos: usize,
+}
+
+impl<T> Cursor<T> {
+    /// Create a new cursor
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            pos: 0,
+        }
+    }
+}
+
+impl Read for Cursor<&[u8]> {
+    fn read<const N: usize>(&mut self, buffer: &mut [u8; N]) -> Result<usize> {
+
+        // get number of items we can copy
+        let n_items = min(self.inner.len() - self.pos, N);
+
+        // split the buffers to make sure
+        let (left_buffer, _) = buffer.split_at_mut(n_items);
+        let (left_inner, _) = self.inner[self.pos..].split_at(n_items);
+
+        // copy items from inner to buffer
+        left_buffer.copy_from_slice(left_inner);
+        self.pos += n_items;
+
+        Result::Ok(n_items)
+    }
+}
+
+impl Read for Cursor<Vec<u8>> {
+    fn read<const N: usize>(&mut self, buffer: &mut [u8; N]) -> Result<usize> {
+        // get number of items we can copy
+        let n_items = min(self.inner.len() - self.pos, N);
+
+        // split the buffers to make sure
+        let (left_buffer, _) = buffer.split_at_mut(n_items);
+        let (left_inner, _) = self.inner[self.pos..].split_at(n_items);
+
+        // copy items from inner to buffer
+        left_buffer.copy_from_slice(left_inner);
+        self.pos += n_items;
+
+        Result::Ok(n_items)
+    }
+}
+
+impl Read for Cursor<&str> {
+    fn read<const N: usize>(&mut self, buffer: &mut [u8; N]) -> Result<usize> {
+        // get number of items we can copy
+        let n_items = min(self.inner.len() - self.pos, N);
+
+        // split the buffers to make sure
+        let (left_buffer, _) = buffer.split_at_mut(n_items);
+        let (left_inner, _) = self.inner[self.pos..].split_at(n_items);
+
+        // copy items from inner to buffer
+        left_buffer.copy_from_slice(left_inner.as_bytes());
+        self.pos += n_items;
+
+        Result::Ok(n_items)
+    }
+}

--- a/src/no_std.rs
+++ b/src/no_std.rs
@@ -3,21 +3,17 @@
 use alloc::vec::Vec;
 use core::cmp::min;
 
-/// The error
-#[derive(Debug)]
-pub enum Error {}
+/// The Result of a read operation.
+pub type Result<T> = core::result::Result<T, ()>;
 
-/// The result of reading
-pub type Result<T> = core::result::Result<T, Error>;
-
-/// A generic reading trait
+/// Allow to Read into a buffer
 pub trait Read {
     /// Read into a buffer.
-    /// @return the number of bytes read into the buffer
+    /// Returns the number of bytes that could be written.
     fn read<const N: usize>(&mut self, buffer: &mut [u8; N]) -> Result<usize>;
 }
 
-/// A Cursor
+/// A simple struct for turning common lists into a Read-able
 pub struct Cursor<T> {
     inner: T,
     pos: usize,

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,22 +1,25 @@
-// #[cfg(feature = "no_std")]
-mod tests_no_std {
-    use murmur3::*;
+// Run some quick tests on our no_std replacements
 
-    #[test]
-    fn test_cursor() {
-        let mut cursor = Cursor::new(vec![1, 2, 3, 4, 5]);
-        let mut buf = [0; 2];
+use murmur3::*;
 
-        assert_eq!(cursor.read(&mut buf).unwrap(), 2);
-        println!("{:?}", buf);
-        assert!(buf == [1, 2]);
+#[test]
+fn test_cursor() {
+    let mut cursor = Cursor::new(vec![1, 2, 3, 4, 5]);
+    let mut buf = [0; 2];
 
-        assert_eq!(cursor.read(&mut buf).unwrap(), 2);
-        println!("{:?}", buf);
-        assert!(buf == [3, 4]);
+    assert_eq!(cursor.read(&mut buf).unwrap(), 2);
+    println!("{:?}", buf);
+    assert!(buf == [1, 2]);
 
-        assert_eq!(cursor.read(&mut buf).unwrap(), 1);
-        println!("{:?}", buf);
-        assert!(buf == [5, 4]);
-    }
+    assert_eq!(cursor.read(&mut buf).unwrap(), 2);
+    println!("{:?}", buf);
+    assert!(buf == [3, 4]);
+
+    assert_eq!(cursor.read(&mut buf).unwrap(), 1);
+    println!("{:?}", buf);
+    assert!(buf == [5, 4]);
+
+    assert_eq!(cursor.read(&mut buf).unwrap(), 0);
+    println!("{:?}", buf);
+    assert!(buf == [5, 4]);
 }

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,0 +1,22 @@
+// #[cfg(feature = "no_std")]
+mod tests_no_std {
+    use murmur3::*;
+
+    #[test]
+    fn test_cursor() {
+        let mut cursor = Cursor::new(vec!{ 1, 2, 3, 4, 5 });
+        let mut buf = [0; 2];
+
+        assert_eq!(cursor.read(&mut buf).unwrap(), 2);
+        println!("{:?}", buf);
+        assert!(buf == [1, 2]);
+
+        assert_eq!(cursor.read(&mut buf).unwrap(), 2);
+        println!("{:?}", buf);
+        assert!(buf == [3, 4]);
+
+        assert_eq!(cursor.read(&mut buf).unwrap(), 1);
+        println!("{:?}", buf);
+        assert!(buf == [5, 4]);
+    }
+}

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -4,7 +4,7 @@ mod tests_no_std {
 
     #[test]
     fn test_cursor() {
-        let mut cursor = Cursor::new(vec!{ 1, 2, 3, 4, 5 });
+        let mut cursor = Cursor::new(vec![1, 2, 3, 4, 5]);
         let mut buf = [0; 2];
 
         assert_eq!(cursor.read(&mut buf).unwrap(), 2);

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -11,7 +11,7 @@ extern crate quickcheck;
 extern crate murmur3;
 extern crate murmur3_sys;
 
-use std::io::Cursor;
+use murmur3::Cursor;
 
 use murmur3::murmur3_32;
 use murmur3_sys::MurmurHash3_x86_32;
@@ -23,7 +23,7 @@ use murmur3::murmur3_x64_128;
 use murmur3_sys::MurmurHash3_x64_128;
 
 quickcheck! {
-    fn quickcheck_32(input:(u32, Vec<u8>)) -> bool{
+    fn quickcheck_32(input:(u32, Vec<u8>)) -> bool {
         let seed = input.0;
         let xs = input.1;
         let output: [u8; 4] = [0; 4];
@@ -32,6 +32,9 @@ quickcheck! {
         };
         let output = u32::from_le_bytes(output);
         let output2 = murmur3_32(&mut Cursor::new(xs), seed).unwrap();
+
+        println!("{:?} {:?}", output, output2);
+
         output == output2
     }
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -33,8 +33,6 @@ quickcheck! {
         let output = u32::from_le_bytes(output);
         let output2 = murmur3_32(&mut Cursor::new(xs), seed).unwrap();
 
-        println!("{:?} {:?}", output, output2);
-
         output == output2
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,7 +8,7 @@
 
 extern crate murmur3;
 
-use std::io::Cursor;
+use murmur3::Cursor;
 
 struct Result {
     string: &'static str,


### PR DESCRIPTION
This PR adds the possibility to disable the `std` feature which makes sure the crate can run on `no_std` environments such as embedded devices. It also adds the `alloc` feature to allow using `Vec` even in `no_std` environments. Since it would be a breaking API change, it has been made opt-in.

To run the tests for this environment, you will need to run it like `cargo test --no-default-features --features alloc`.

Running the benchmarks locally, the performance goes slightly up.