### PR TITLE
Add non-copying version of murmur3_32 that reads directly from a byte buffer

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-
 extern crate murmur3_sys;
 extern crate test;
 
@@ -20,6 +19,17 @@ fn bench_32(b: &mut Bencher) {
     b.iter(|| {
         let mut tmp = Cursor::new(&string[0..string.len()]);
         murmur3_32(&mut tmp, 0)
+    });
+}
+
+#[bench]
+fn bench_32_slice(b: &mut Bencher) {
+    let string: &[u8] =
+        test::black_box(b"Lorem ipsum dolor sit amet, consectetur adipisicing elit");
+    b.bytes = string.len() as u64;
+    b.iter(|| {
+        let tmp = &string[0..string.len()];
+        murmur3_32_of_slice(tmp, 0);
     });
 }
 

--- a/src/murmur3_32.rs
+++ b/src/murmur3_32.rs
@@ -6,8 +6,8 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-use std::io::{Read, Result};
 use std::cmp::min;
+use std::io::{Read, Result};
 
 use crate::read_bytes;
 
@@ -64,7 +64,7 @@ pub fn murmur3_32<T: Read>(source: &mut T, seed: u32) -> Result<u32> {
 /// Use the 32 bit variant of murmur3 to hash [u8] without copying the buffer.
 ///
 /// # Example
-/// 
+///
 /// ```
 /// use murmur3::murmur3_32::nocopy;
 /// let hash_result = murmur3_32_nocopy("hello world".as_bytes(), 0)
@@ -81,33 +81,34 @@ pub fn murmur3_32_nocopy(source: &[u8], seed: u32) -> u32 {
                 let k: u32 = buffer[0] as u32;
                 state ^= calc_k(k);
                 return finish(state, processed);
-            },
+            }
             2 => {
                 processed += 2;
-                let k: u32 = ((buffer[1] as u32) << 8) | (buffer [0] as u32);
-                state ^=  calc_k(k);
+                let k: u32 = ((buffer[1] as u32) << 8) | (buffer[0] as u32);
+                state ^= calc_k(k);
                 return finish(state, processed);
-            },
+            }
             3 => {
                 processed += 3;
                 let k: u32 =
-                    ((buffer[2] as u32) << 16) | ((buffer [1] as u32) << 8) | (buffer[0] as u32);
+                    ((buffer[2] as u32) << 16) | ((buffer[1] as u32) << 8) | (buffer[0] as u32);
                 state ^= calc_k(k);
                 return finish(state, processed);
-            },
+            }
             4 => {
                 processed += 4;
-                let k: u32 =
-                    ((buffer[3] as u32) << 24) | ((buffer[2] as u32) << 16) |
-                    ((buffer[1] as u32) << 8) | (buffer[0] as u32);
-                state ^= calc_k(k); 
+                let k: u32 = ((buffer[3] as u32) << 24)
+                    | ((buffer[2] as u32) << 16)
+                    | ((buffer[1] as u32) << 8)
+                    | (buffer[0] as u32);
+                state ^= calc_k(k);
                 state = state.rotate_left(R2);
                 state = (state.wrapping_mul(M)).wrapping_add(N);
                 buffer = &buffer[4..];
-            },
-            _ => unreachable!()
+            }
+            _ => unreachable!(),
         };
-    };
+    }
 }
 
 fn finish(state: u32, processed: u32) -> u32 {

--- a/src/murmur3_32.rs
+++ b/src/murmur3_32.rs
@@ -7,6 +7,7 @@
 // modified, or distributed except according to those terms.
 
 use std::io::{Read, Result};
+use std::cmp::min;
 
 use crate::read_bytes;
 
@@ -58,6 +59,55 @@ pub fn murmur3_32<T: Read>(source: &mut T, seed: u32) -> Result<u32> {
             _ => panic!("Internal buffer state failure"),
         }
     }
+}
+
+/// Use the 32 bit variant of murmur3 to hash [u8] without copying the buffer.
+///
+/// # Example
+/// 
+/// ```
+/// use murmur3::murmur3_32::nocopy;
+/// let hash_result = murmur3_32_nocopy("hello world".as_bytes(), 0)
+/// ```
+pub fn murmur3_32_nocopy(source: &[u8], seed: u32) -> u32 {
+    let mut buffer = source;
+    let mut processed = 0;
+    let mut state = seed;
+    loop {
+        match min(buffer.len(), 4) {
+            0 => return finish(state, processed),
+            1 => {
+                processed += 1;
+                let k: u32 = buffer[0] as u32;
+                state ^= calc_k(k);
+                return finish(state, processed);
+            },
+            2 => {
+                processed += 2;
+                let k: u32 = ((buffer[1] as u32) << 8) | (buffer [0] as u32);
+                state ^=  calc_k(k);
+                return finish(state, processed);
+            },
+            3 => {
+                processed += 3;
+                let k: u32 =
+                    ((buffer[2] as u32) << 16) | ((buffer [1] as u32) << 8) | (buffer[0] as u32);
+                state ^= calc_k(k);
+                return finish(state, processed);
+            },
+            4 => {
+                processed += 4;
+                let k: u32 =
+                    ((buffer[3] as u32) << 24) | ((buffer[2] as u32) << 16) |
+                    ((buffer[1] as u32) << 8) | (buffer[0] as u32);
+                state ^= calc_k(k); 
+                state = state.rotate_left(R2);
+                state = (state.wrapping_mul(M)).wrapping_add(N);
+                buffer = &buffer[4..];
+            },
+            _ => unreachable!()
+        };
+    };
 }
 
 fn finish(state: u32, processed: u32) -> u32 {

--- a/src/murmur3_32.rs
+++ b/src/murmur3_32.rs
@@ -66,8 +66,8 @@ pub fn murmur3_32<T: Read>(source: &mut T, seed: u32) -> Result<u32> {
 /// # Example
 ///
 /// ```
-/// use murmur3::murmur3_32::nocopy;
-/// let hash_result = murmur3_32_nocopy("hello world".as_bytes(), 0)
+/// use murmur3::murmur3_32_of_slice;
+/// let hash_result = murmur3_32_of_slice("hello world".as_bytes(), 0);
 /// ```
 pub fn murmur3_32_of_slice(source: &[u8], seed: u32) -> u32 {
     let mut buffer = source;

--- a/src/murmur3_32.rs
+++ b/src/murmur3_32.rs
@@ -69,7 +69,7 @@ pub fn murmur3_32<T: Read>(source: &mut T, seed: u32) -> Result<u32> {
 /// use murmur3::murmur3_32::nocopy;
 /// let hash_result = murmur3_32_nocopy("hello world".as_bytes(), 0)
 /// ```
-pub fn murmur3_32_nocopy(source: &[u8], seed: u32) -> u32 {
+pub fn murmur3_32_of_slice(source: &[u8], seed: u32) -> u32 {
     let mut buffer = source;
     let mut processed = 0;
     let mut state = seed;
@@ -113,7 +113,7 @@ pub fn murmur3_32_nocopy(source: &[u8], seed: u32) -> u32 {
 
 fn finish(state: u32, processed: u32) -> u32 {
     let mut hash = state;
-    hash ^= processed as u32;
+    hash ^= processed;
     hash ^= hash.wrapping_shr(R1);
     hash = hash.wrapping_mul(C1);
     hash ^= hash.wrapping_shr(R2);

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -13,7 +13,7 @@ extern crate murmur3_sys;
 
 use std::io::Cursor;
 
-use murmur3::murmur3_32;
+use murmur3::{murmur3_32, murmur3_32_of_slice};
 use murmur3_sys::MurmurHash3_x86_32;
 
 use murmur3::murmur3_x86_128;
@@ -32,6 +32,20 @@ quickcheck! {
         };
         let output = u32::from_le_bytes(output);
         let output2 = murmur3_32(&mut Cursor::new(xs), seed).unwrap();
+        output == output2
+    }
+}
+
+quickcheck! {
+    fn quickcheck_32_slice(input:(u32, Vec<u8>)) -> bool{
+        let seed = input.0;
+        let xs = input.1;
+        let mut output: [u8; 4] = [0; 4];
+        unsafe {
+            MurmurHash3_x86_32(xs.as_ptr() as _, xs.len() as i32, seed, output.as_mut_ptr() as _)
+        };
+        let output = u32::from_le_bytes(output);
+        let output2 = murmur3_32_of_slice(&xs[..], seed);
         output == output2
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -368,6 +368,13 @@ fn test_static_strings() {
             test.string
         );
 
+        assert_eq!(
+            murmur3::murmur3_32_of_slice(test.string.as_bytes(), 0),
+            test.hash_32,
+            "Failed 32_of_slice on string {}",
+            test.string,
+        );
+
         let mut string = String::new();
         str_as_chained_cursor(test.string)
             .read_to_string(&mut string)


### PR DESCRIPTION
I'm using murmur3 on very large in-memory buffers. My initial approach was to create a wrapper type around my buffers that implements `read()`, but the overhead of the call to this function for each 4 bytes in very large buffers made the hashing unreasonably slow. 

This PR adds an implementation which directly hashes a byte buffer, without the necessity of copying into a local 4-byte buffer. It immediately and significantly improved the performance of my application.