### PR TITLE
Introduce murmur3_32_of_slices

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -34,6 +34,18 @@ fn bench_32_slice(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_32_slices(b: &mut Bencher) {
+    let string: &[u8] =
+        test::black_box(b"Lorem ipsum dolor sit amet, consectetur adipisicing elit");
+
+    b.bytes = string.len() as u64;
+    b.iter(|| {
+        let tmp = &string[0..string.len()];
+        murmur3_32_of_slices(&[tmp], 0);
+    });
+}
+
+#[bench]
 fn bench_c_32(b: &mut Bencher) {
     let string: &[u8] =
         test::black_box(b"Lorem ipsum dolor sit amet, consectetur adipisicing elit");

--- a/src/murmur3_32.rs
+++ b/src/murmur3_32.rs
@@ -111,6 +111,112 @@ pub fn murmur3_32_of_slice(source: &[u8], seed: u32) -> u32 {
     }
 }
 
+/// Use the 32 bit variant of murmur3 to hash [[u8],..] without copying the buffers.
+///
+/// # Example
+///
+/// ```
+/// use murmur3::murmur3_32_of_slices;
+/// let hash_result = murmur3_32_of_slices(&["hello".as_bytes()," world".as_bytes()], 0);
+/// ```
+pub fn murmur3_32_of_slices(source: &[&[u8]], seed: u32) -> u32 {
+    let mut state = seed;
+    let mut processed:usize = 0;
+    let mut k: u32=0u32;
+    let mut k_offset: u8=0u8;
+    for slice in source {
+        let mut buffer = *slice;
+        let mut buffer_len = buffer.len();
+        processed += buffer_len;
+        while buffer_len != 0 {
+            match k_offset {
+                0 => {
+                    match buffer_len {
+                        3 => {
+                            k |= (buffer[2] as u32) << 16 | (buffer[1] as u32) << 8 | (buffer[0] as u32);
+                            buffer = &buffer[3..];
+                            k_offset = 3;
+                        },
+                        2 => {
+                            k |= (buffer[1] as u32) << 8 | (buffer[0] as u32);
+                            buffer = &buffer[2..];
+                            k_offset = 2;
+                        },
+                        1 => {
+                            k |= buffer[0] as u32;
+                            buffer = &buffer[1..];
+                            k_offset = 1;
+                        },
+                        _ => {
+                            k = ((buffer[3] as u32) << 24)
+                                | ((buffer[2] as u32) << 16)
+                                | ((buffer[1] as u32) << 8)
+                                | (buffer[0] as u32);
+                            buffer = &buffer[4..];
+                            k_offset = 0;
+                        }
+                    }
+                },
+                1 => {
+                    match buffer_len {
+                        2 => {
+                            k |= (buffer[1] as u32) << 16 | (buffer[0] as u32) <<8;
+                            buffer = &buffer[2..];
+                            k_offset = 3;
+                        },
+                        1 => {
+                            k |= (buffer[0] as u32)<<8;
+                            buffer = &buffer[1..];
+                            k_offset = 2;
+                        },
+                        _ => {
+                            k |= (buffer[2] as u32) << 24 | (buffer[1] as u32) << 16 | (buffer[0] as u32) <<8;
+                            buffer = &buffer[3..];
+                            k_offset = 0;
+                        },
+                    }
+                },
+                2 => {
+                    match buffer_len {
+                        1 => {
+                            k |= (buffer[0] as u32)<<16;
+                            buffer = &buffer[1..];
+                            k_offset = 3;
+                        },
+                        _ => {
+                            k |= (buffer[1] as u32) << 24 | (buffer[0] as u32)<<16;
+                            buffer = &buffer[2..];
+                            k_offset = 0;
+                        },
+                    }
+                },
+                3 => {
+                    k |= (buffer[0] as u32)<<24;
+                    buffer = &buffer[1..];
+                    k_offset = 0;
+                    }
+                _ => unreachable!()
+            }
+
+            if k_offset == 0 {
+                // all 4-bytes ware collected
+                state ^= calc_k(k);
+                state = state.rotate_left(R2);
+                state = (state.wrapping_mul(M)).wrapping_add(N);
+                k = 0u32;
+            }
+            buffer_len = buffer.len();
+        }
+    }
+
+    if k_offset != 0 {
+        // k still has some unprocessed data
+        state ^= calc_k(k);
+    }
+
+    finish(state, processed as u32)
+}
+
 fn finish(state: u32, processed: u32) -> u32 {
     let mut hash = state;
     hash ^= processed;

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -14,7 +14,7 @@ extern crate murmur3_sys;
 use std::io::Cursor;
 
 use murmur3::{
-    murmur3_32, murmur3_32_of_slice, murmur3_x64_128_of_slice, murmur3_x86_128_of_slice,
+    murmur3_32, murmur3_32_of_slice, murmur3_32_of_slices, murmur3_x64_128_of_slice, murmur3_x86_128_of_slice,
 };
 use murmur3_sys::MurmurHash3_x86_32;
 
@@ -48,6 +48,20 @@ quickcheck! {
         };
         let output = u32::from_le_bytes(output);
         let output2 = murmur3_32_of_slice(&xs[..], seed);
+        output == output2
+    }
+}
+
+quickcheck! {
+    fn quickcheck_32_slices(input:(u32, Vec<u8>)) -> bool{
+        let seed = input.0;
+        let xs = input.1;
+        let mut output: [u8; 4] = [0; 4];
+        unsafe {
+            MurmurHash3_x86_32(xs.as_ptr() as _, xs.len() as i32, seed, output.as_mut_ptr() as _)
+        };
+        let output = u32::from_le_bytes(output);
+        let output2 = murmur3_32_of_slices(&[&xs[..]], seed);
         output == output2
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -375,6 +375,27 @@ fn test_static_strings() {
             test.string,
         );
 
+        assert_eq!(
+            murmur3::murmur3_32_of_slices(&[test.string.as_bytes()], 0),
+            test.hash_32,
+            "Failed 32_of_slice on string {}",
+            test.string,
+        );
+
+        // dealing with multiple unaligned buffers is the tricky part, let's test all the cases
+        for i in 0..=test.string.len() {
+            let mut full_slice = test.string.as_bytes();
+            if let Some(first) = full_slice.split_off(..i) {
+                assert_eq!(
+                    murmur3::murmur3_32_of_slices(&[first, full_slice], 0),
+                    test.hash_32,
+                    "Failed 32_of_slices on string {}, split in {}",
+                    test.string,
+                    i,
+                );
+            }
+        }
+
         let mut string = String::new();
         str_as_chained_cursor(test.string)
             .read_to_string(&mut string)


### PR DESCRIPTION
Add murmur3_32_of_slices that reads directly from multiple byte buffers.

According to bench it's usually slightly faster on x86_64 (Broadwell)
```
test bench_32_slice  ... bench:           5.71 ns/iter (+/- 0.79) = 11200 MB/s
test bench_32_slices ... bench:           5.56 ns/iter (+/- 0.82) = 11200 MB/s
```

6% faster on AMD EPYC 7D13
```
test bench_32_slice  ... bench:           8.47 ns/iter (+/- 0.05) = 7000 MB/s
test bench_32_slices ... bench:           7.94 ns/iter (+/- 0.03) = 8000 MB/s
```

18% on aarch64 (apple M4):
```
test bench_32_slice      ... bench:           4.14 ns/iter (+/- 0.39) = 14000 MB/s
test bench_32_slices     ... bench:           3.37 ns/iter (+/- 0.03) = 18666 MB/s
```